### PR TITLE
fix ButtobProps type error

### DIFF
--- a/src/components/Careers/Career10.tsx
+++ b/src/components/Careers/Career10.tsx
@@ -94,8 +94,8 @@ const position = {
   contractType: "Contract Type",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career11.tsx
+++ b/src/components/Careers/Career11.tsx
@@ -92,8 +92,8 @@ const position = {
   contractType: "Contract Type",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career12.tsx
+++ b/src/components/Careers/Career12.tsx
@@ -94,8 +94,8 @@ const position = {
   contractType: "Contract Type",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career13.tsx
+++ b/src/components/Careers/Career13.tsx
@@ -92,8 +92,8 @@ const position = {
   contractType: "Contract Type",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career14.tsx
+++ b/src/components/Careers/Career14.tsx
@@ -92,8 +92,8 @@ const position = {
   contractType: "Contract Type",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career15.tsx
+++ b/src/components/Careers/Career15.tsx
@@ -94,8 +94,8 @@ const position = {
   contractType: "Contract Type",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career19.tsx
+++ b/src/components/Careers/Career19.tsx
@@ -11,7 +11,7 @@ type PositionProps = {
   description: string;
   location: string;
   contractType: string;
-  button: ButtonProps;
+  button: ButtonProps & { title: string };
 };
 
 type PositionCardProps = {
@@ -115,7 +115,12 @@ const position = {
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique.",
   location: "Location",
   contractType: "Contract Type",
-  button: { title: "Apply Now", variant: "link", size: "link", iconRight: <RxChevronRight /> },
+  button: {
+    title: "Apply Now",
+    variant: "link" as const,
+    size: "link" as const,
+    iconRight: <RxChevronRight />,
+  },
 };
 
 export const Career19Defaults: Props = {

--- a/src/components/Careers/Career20.tsx
+++ b/src/components/Careers/Career20.tsx
@@ -115,7 +115,7 @@ const position = {
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique.",
   location: "Location",
   contractType: "Contract Type",
-  button: { title: "Apply Now", variant: "link", size: "link", iconRight: <RxChevronRight /> },
+  button: { title: "Apply Now", variant: "link" as const, size: "link" as const, iconRight: <RxChevronRight /> },
 };
 
 export const Career20Defaults: Props = {

--- a/src/components/Careers/Career21.tsx
+++ b/src/components/Careers/Career21.tsx
@@ -117,7 +117,7 @@ const position = {
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique.",
   location: "Location",
   contractType: "Contract Type",
-  button: { title: "Apply Now", variant: "link", size: "link", iconRight: <RxChevronRight /> },
+  button: { title: "Apply Now", variant: "link" as const, size: "link" as const, iconRight: <RxChevronRight /> },
 };
 
 export const Career21Defaults: Props = {

--- a/src/components/Careers/Career22.tsx
+++ b/src/components/Careers/Career22.tsx
@@ -92,8 +92,8 @@ const position = {
   contractType: "Contract Type",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career23.tsx
+++ b/src/components/Careers/Career23.tsx
@@ -92,8 +92,8 @@ const position = {
   contractType: "Contract Type",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career24.tsx
+++ b/src/components/Careers/Career24.tsx
@@ -104,8 +104,8 @@ const job = {
   contractType: "Contract Type",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career25.tsx
+++ b/src/components/Careers/Career25.tsx
@@ -111,8 +111,8 @@ const job = {
   contractType: "Contract Type",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career26.tsx
+++ b/src/components/Careers/Career26.tsx
@@ -104,8 +104,8 @@ const position = {
   contractType: "Contract Type",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career27.tsx
+++ b/src/components/Careers/Career27.tsx
@@ -103,8 +103,8 @@ const position = {
   contractType: "Contract Type",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career3.tsx
+++ b/src/components/Careers/Career3.tsx
@@ -80,8 +80,8 @@ const job = {
   url: "#",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career4.tsx
+++ b/src/components/Careers/Career4.tsx
@@ -76,8 +76,8 @@ const job = {
   url: "#",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career5.tsx
+++ b/src/components/Careers/Career5.tsx
@@ -76,8 +76,8 @@ const job = {
   url: "#",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career6.tsx
+++ b/src/components/Careers/Career6.tsx
@@ -78,8 +78,8 @@ const job = {
   url: "#",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career7.tsx
+++ b/src/components/Careers/Career7.tsx
@@ -82,8 +82,8 @@ const job = {
   url: "#",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career8.tsx
+++ b/src/components/Careers/Career8.tsx
@@ -82,8 +82,8 @@ const job = {
   url: "#",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 

--- a/src/components/Careers/Career9.tsx
+++ b/src/components/Careers/Career9.tsx
@@ -86,8 +86,8 @@ const job = {
   url: "#",
   button: {
     title: "Apply Now",
-    variant: "secondary",
-    size: "sm",
+    variant: "secondary" as const,
+    size: "sm" as const,
   },
 };
 


### PR DESCRIPTION
Added const type to Button.
Explicit Assertion
Force TypeScript to acknowledge that the button.variant is one of the expected types by explicitly asserting it as such:
const job = {
  title: "Job Title",
  location: "Location",
  description:
    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat. Aenean faucibus nibh et justo cursus id rutrum lorem imperdiet. Nunc ut sem vitae risus tristique posuere.",
  url: "#",
  button: {
    title: "Apply Now",
    variant: "secondary" as "secondary", // Explicitly match the literal type
    size: "sm" as "sm",                 // Ensure the size matches the type
  },
};
